### PR TITLE
Resolve the problem where multiple keys are used

### DIFF
--- a/Cache/Memcached.php
+++ b/Cache/Memcached.php
@@ -505,7 +505,17 @@ class Memcached
 	{
 		$namespaceVersion  = $this->getNamespaceVersion();
 
-		return sprintf('%s[%s][%s]', $this->namespace, $id, $namespaceVersion);
+		if (is_array($id)) {
+			/*
+			 * If the id is an array, then we need to adjust all keys consistently. This
+			 * will recursively adjust all the keys to use the configured namespace values
+			 */
+			return array_map(function ($key) {
+			    return $this->getNamespacedId($key);
+			}, $id);
+		} else {
+			return sprintf('%s[%s][%s]', $this->namespace, $id, $namespaceVersion);	
+		}
 	}
 
 	/**


### PR DESCRIPTION
I've noticed that in the case of getMulti the bundle will crash.

This is because getMulti can receive an array, and the function getNamespaceId will fail to run sprintf on the array.

The fix is relatively simple - if the passed in value is an array, apply the function to each of the values of the array rather than the array itself.

This resolves the problem with getMulti, and while I've not tested it myself I believe will resolve the problem with other "multi" functions.